### PR TITLE
[NEW] haeppie.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -22,6 +22,7 @@
     "godaddy.com",
     "google.com",
     "hanko.io",
+    "haeppie.com",
     "homedepot.com",
     "horizon.pics",
     "hyatt.com",


### PR DESCRIPTION
-   **Domain Name**: 
haeppie.com
-   **Purpose**:
Information Technology
-   **Relevance**:
<img width="808" alt="image" src="https://github.com/Dashlane/passkeys-resources/assets/4266283/f1e5021c-27dc-40c1-a931-74a121ea373a">