### PR TITLE
[NEW] airnewzealand.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -1,5 +1,6 @@
 [
     "adobe.com",
+    "airnewzealand.com",
     "arpari.com",
     "authgear.com",
     "bestbuy.com",


### PR DESCRIPTION
-   **Domain Name**: 
airnewzealand.com
-   **Purpose**:
Airline
-   **Relevance**:
https://www.airnewzealand.com/cyber-security-account-protection
![image](https://github.com/Dashlane/passkeys-resources/assets/8578329/191930e6-9fed-45ce-a033-58634d396cfb)

-   **Additional Information**:

