### PR TITLE
[NEW] moneyforward.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -42,6 +42,7 @@
     "marshmallow-qa.com",
     "microsoft.com",
     "monespacesante.fr",
+    "moneyforward.com",
     "namecheap.com",
     "nintendo.com",
     "nvidia.com",


### PR DESCRIPTION
-   **Domain Name**: 
moneyforward.com
-   **Purpose**:
Finance
-   **Relevance**:
https://corp.moneyforward.com/news/info/20230403-mf-press-2/
-   **Additional Information**:
The signin page https://id.moneyforward.com/sign_in has webauthn (in the HTML)
