### PR TITLE
[NEW] playstation.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -65,6 +65,7 @@
     "pastery.net",
     "payfit.com",
     "paypal.com",
+    "playstation.com",
     "porkbun.com",
     "qapital.com",
     "rad.dad",


### PR DESCRIPTION
-   **Domain Name**: 
playstation.com
-   **Purpose**:
gaming
-   **Relevance**:
https://www.playstation.com/en-us/passkey/
