### PR TITLE
[NEW] michigan.gov

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -47,6 +47,7 @@
     "mangadex.org",
     "marketcircle.com",
     "marshmallow-qa.com",
+    "michigan.gov",
     "microsoft.com",
     "monespacesante.fr",
     "moneybird.com",


### PR DESCRIPTION
-   **Domain Name**: 
michigan.gov
-   **Purpose**:
US State website
-   **Relevance**:
https://milogin.michigan.gov/
Log In Passwordless