### PR TITLE
[NEW] revolut.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -70,6 +70,7 @@
     "porkbun.com",
     "qapital.com",
     "rad.dad",
+    "revolut.com"
     "robinhood.com",
     "roblox.com",
     "sandbox.fusionauth.io",


### PR DESCRIPTION
-   **Domain Name**: 
revolut.com
-   **Purpose**:
Banking
-   **Relevance**:
https://www.corbado.com/blog/revolut-passkeys