### PR TITLE
Add olympics.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -58,6 +58,7 @@
     "nvidia.com",
     "offshoot.rentals",
     "okta.com",
+    "olympics.com",
     "omg.lol",
     "onlyfans.com",
     "passage.1password.com",


### PR DESCRIPTION
-   **Domain Name**: 
olympics.com
-   **Purpose**:
Official website of the Olympics
-   **Relevance**:
Reported by a Dashlane colleague and also on OwnID's passkey directory
-   **Additional Information**:

