### PR TITLE
[NEW] bmwusa.com + bmw.co.uk

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -8,6 +8,8 @@
     "bestbuy.com",
     "beyondidentity.com",
     "binance.com",
+    "bmw.co.uk",
+    "bmwusa.com",
     "bookmyname.com",
     "boursobank.com",
     "bridgecrest.com",


### PR DESCRIPTION
-   **Domain Name**: 
bmw.co.uk + bmwusa.com
-   **Purpose**:
vroom vroom
-   **Relevance**:
<img width="1262" alt="image" src="https://github.com/Dashlane/passkeys-resources/assets/8578329/1c650638-3c5b-427c-8469-0e495f078a76">
