### PR TITLE
[NEW] macif.fr

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -47,6 +47,7 @@
     "linkedin.com",
     "login.gov",
     "lowes.com",
+    "macif.fr",
     "magic.link",
     "mangadex.org",
     "marketcircle.com",


### PR DESCRIPTION
-   **Domain Name**: 
macif.fr
-   **Purpose**:
macif is a French insurance provider.
-   **Relevance**:
<!--- Link proof with images or videos of the working flow that shows the domain supporting passkeys. --->
![image](https://github.com/user-attachments/assets/4fb733e7-e58a-4a66-b057-79c2b038311f)
