### PR TITLE
[NEW] ubank.com.au

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -91,6 +91,7 @@
     "tiktok.com",
     "trusona.com",
     "twitter.com",
+    "ubank.com.au",
     "uber.com",
     "vaultvision.com",
     "vercel.com",


### PR DESCRIPTION
-   **Domain Name**: 
ubank.com.au
-   **Purpose**:
Finance
-   **Relevance**:
https://www.ubank.com.au/help/current/app-and-online-banking/passkeys/what-are-passkeys
