### PR TITLE
[NEW] kraken.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -43,6 +43,7 @@
     "justpass.me",
     "kayak.com",
     "kenwoodworld.com",
+    "kraken.com",
     "laakari.chat",
     "linkedin.com",
     "login.gov",


### PR DESCRIPTION
-   **Domain Name**: 
kraken.com
-   **Purpose**:
Crypto currencies
-   **Relevance**:
https://support.kraken.com/hc/en-us/articles/what-is-a-passkey