### PR TITLE
[NEW] abanca.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -1,4 +1,5 @@
 [
+    "abanca.com",
     "adobe.com",
     "airnewzealand.com",
     "amazon.com",


### PR DESCRIPTION
-   **Domain Name**: 
abanca.com
-   **Purpose**:
Banking
-   **Relevance**:
https://comunicacion.abanca.com/es/noticias/abanca-primer-banco-espanol-en-implantar-la-tecnologia-de-llaves-de-acceso-en-la-banca-movil-para-reforzar-la-seguridad-de-sus-clientes/