### PR TITLE
[NEW] aflac.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -1,5 +1,6 @@
 [
     "adobe.com",
+    "aflac.com",
     "airnewzealand.com",
     "amazon.com",
     "apple.com",


### PR DESCRIPTION
-   **Domain Name**: 
aflac.com
-   **Purpose**:
Insurance
-   **Relevance**:
https://www.csoonline.com/article/3518747/aflacs-shift-to-passkeys-brings-big-business-benefits.html