### PR TITLE
[NEW] sktelecom.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -89,6 +89,7 @@
     "sandbox.fusionauth.io",
     "shop.app",
     "shopify.com",
+    "sktelecom.com",
     "stripe.com",
     "synology.com",
     "tailscale.com",


### PR DESCRIPTION
-   **Domain Name**: 
sktelecom.com
-   **Purpose**:
Telecom
-   **Relevance**:
https://fidoalliance.org/sk-telecom-announces-adoption-of-passkeys-for-online-users-in-korea/