### PR TITLE
[NEW] ring.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -84,6 +84,7 @@
     "qapital.com",
     "rad.dad",
     "revolut.com",
+    "ring.com",
     "robinhood.com",
     "roblox.com",
     "sandbox.fusionauth.io",


### PR DESCRIPTION
-   **Domain Name**: 
Ring.com
-   **Purpose**:
Security cameras
-   **Relevance**:
https://ring.com/gb/en/support/articles/mbe2i/passwordless-authentication