### PR TITLE
[NEW] bolt.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -13,6 +13,7 @@
     "binance.com",
     "bmw.co.uk",
     "bmwusa.com",
+    "bolt.com",
     "bookmyname.com",
     "boursobank.com",
     "bridgecrest.com",


### PR DESCRIPTION
-   **Domain Name**: 
bolt.com
-   **Purpose**:
E-commerce
-   **Relevance**:
https://www.bolt.com/blog/bolt-launches-passkey-authentication