### PR TITLE
add vinci-autoroutes.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -106,6 +106,7 @@
     "uber.com",
     "vaultvision.com",
     "vercel.com",
+    "vinci-autoroutes.com",
     "virginmedia.com",
     "webauthn.io",
     "wellsfargo.com",


### PR DESCRIPTION
-   **Domain Name**: 
vinci-autoroutes.com
-   **Purpose**:
Vinci Autoroutes is a maintainer of highways in France
-   **Additional Information**:
You can use a passkey to login to https://espaceabonnes.vinci-autoroutes.com/