### PR TITLE
[NEW] carta.com

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -20,6 +20,7 @@
     "bridgecrest.com",
     "cardpointers.com",
     "carnival.com",
+    "carta.com",
     "cloudflare.com",
     "coinbase.com",
     "corbado.com",


### PR DESCRIPTION
-   **Domain Name**: 
carta.com
-   **Purpose**:
Cloud-based solution for equity and fund management
-   **Relevance**:
https://support.carta.com/kb/guide/en/how-to-troubleshoot-issues-logging-into-carta-0tyLW4pmn3/Steps/3724933,3962201,3898803
