### PR TITLE
[NEW] vicroads.vic.gov.au

### DIFF
--- a/resources/compatible-domains.json
+++ b/resources/compatible-domains.json
@@ -110,6 +110,7 @@
     "uber.com",
     "vaultvision.com",
     "vercel.com",
+    "vicroads.vic.gov.au",
     "vinci-autoroutes.com",
     "virginmedia.com",
     "webauthn.io",


### PR DESCRIPTION
-   **Domain Name**: 
vicroads.vic.gov.au
-   **Purpose**:
Transport
-   **Relevance**:
https://www.vicroads.vic.gov.au/newsmedia/2024/vicroads-launches-passkeys-to-enhance-online-security